### PR TITLE
BD-909:Relicense RDKSplashScreen to Metrological Apache

### DIFF
--- a/dist/web/js/src/appBundle.js
+++ b/dist/web/js/src/appBundle.js
@@ -5,7 +5,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -129,7 +129,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -165,7 +165,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -256,7 +256,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -345,7 +345,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -366,7 +366,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -521,7 +521,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -916,7 +916,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -1159,7 +1159,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -1237,7 +1237,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -1435,7 +1435,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -1471,7 +1471,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -1586,7 +1586,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Reason for change:Relicense RDKSplashScreen to Metrological Apache
Test Procedure: Jenkin build should pass after License header changes for RDK for listed repos
BD-909:Relicense RDKSplashScreen to Metrological Apache
Risks: None